### PR TITLE
make API fields private, replace deprecated methods

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,17 +2,22 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
-
-	"github.com/digineo/3cx_exporter/exporter"
+	"os"
 )
 
-func parseConfig(path string) (*exporter.API, error) {
-	data, err := ioutil.ReadFile(path)
+type Config struct {
+	Hostname string `json:"Hostname"`
+	Username string `json:"Username"`
+	Password string `json:"Password"`
+}
+
+func parseConfig(path string) (Config, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return Config{}, err
 	}
 
-	api := exporter.API{}
-	return &api, json.Unmarshal(data, &api)
+	var config Config
+	err = json.Unmarshal(data, &config)
+	return config, err
 }

--- a/exporter/api.go
+++ b/exporter/api.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
@@ -15,10 +15,18 @@ import (
 
 // API is the interface to 3CX
 type API struct {
-	Hostname string
-	Username string
-	Password string
+	hostname string
+	username string
+	password string
 	client   *http.Client
+}
+
+func NewAPI(hostname, username, password string) API {
+	return API{
+		hostname: hostname,
+		username: username,
+		password: password,
+	}
 }
 
 // ErrAuthentication is returned on HTTP status 401
@@ -32,7 +40,7 @@ func (api *API) Login() error {
 	credentials := struct {
 		Username string
 		Password string
-	}{api.Username, api.Password}
+	}{api.username, api.password}
 
 	body, _ := json.Marshal(&credentials)
 
@@ -46,7 +54,7 @@ func (api *API) Login() error {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -60,7 +68,7 @@ func (api *API) Login() error {
 }
 
 func (api *API) buildURI(path string) string {
-	return fmt.Sprintf("https://%s/api/%s", api.Hostname, path)
+	return fmt.Sprintf("https://%s/api/%s", api.hostname, path)
 }
 
 // getResponse does a GET request and parses the JSON response

--- a/exporter/service_test.go
+++ b/exporter/service_test.go
@@ -2,7 +2,7 @@ package exporter
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +13,7 @@ func TestServiceList(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	data, err := ioutil.ReadFile("fixtures/ServiceList.json")
+	data, err := os.ReadFile("fixtures/ServiceList.json")
 	require.NoError(err)
 
 	serviceList := ServiceList{}

--- a/exporter/status_test.go
+++ b/exporter/status_test.go
@@ -2,7 +2,7 @@ package exporter
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,7 +11,7 @@ import (
 func TestStatus(t *testing.T) {
 	require := require.New(t)
 
-	data, err := ioutil.ReadFile("fixtures/SystemStatus.json")
+	data, err := os.ReadFile("fixtures/SystemStatus.json")
 	require.NoError(err)
 
 	status := SystemStatus{}

--- a/exporter/trunk_test.go
+++ b/exporter/trunk_test.go
@@ -2,7 +2,7 @@ package exporter
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +13,7 @@ func TestTrunks(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	data, err := ioutil.ReadFile("fixtures/TrunkList.json")
+	data, err := os.ReadFile("fixtures/TrunkList.json")
 	require.NoError(err)
 
 	response := struct {

--- a/main.go
+++ b/main.go
@@ -11,15 +11,16 @@ import (
 )
 
 func main() {
-	config := flag.String("config", "config.json", "Path to config file")
+	configFile := flag.String("config", "config.json", "Path to config file")
 	listen := flag.String("listen", ":9523", "Listening on")
 	flag.Parse()
 
-	api, err := parseConfig(*config)
+	config, err := parseConfig(*configFile)
 	checkErr(err)
+	api := exporter.NewAPI(config.Hostname, config.Username, config.Password)
 	checkErr(api.Login())
 
-	prometheus.MustRegister(&exporter.Exporter{API: *api})
+	prometheus.MustRegister(&exporter.Exporter{API: api})
 	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(*listen, nil))
 }


### PR DESCRIPTION
Hi! I decided that it would be a better practice to keep sensitive API fields private.
Also, I replaced deprecated methods with valid replacements. 